### PR TITLE
Add dkms-install and dkms-remove hooks

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -10,6 +10,10 @@ pachooks - sample hooks for libalpm/pacman
 
 =item check-suid - print post-install warnings for suid/getcap binaries
 
+=item dkms-install - build dkms modules after installing or upgrading a kernel
+
+=item dkms-remove - remove all dkms modules before removing a kernel
+
 =item fc-cache - rebuild system font information cache
 
 =item info-install, info-remove - update info file database

--- a/hooks/dkms-install.hook
+++ b/hooks/dkms-install.hook
@@ -1,0 +1,13 @@
+[Trigger]
+Operation = Install
+Operation = Upgrade
+Type = File
+Target = usr/lib/modules/*/
+Target = !usr/lib/modules/extramodules-*
+Target = !usr/lib/modules/*/?*
+
+[Action]
+Exec = /usr/share/alpm/hooks.bin/dkms-install
+When = PostTransaction
+Depends = dkms
+NeedsTargets

--- a/hooks/dkms-remove.hook
+++ b/hooks/dkms-remove.hook
@@ -1,0 +1,12 @@
+[Trigger]
+Operation = Remove
+Type = File
+Target = usr/lib/modules/*/
+Target = !usr/lib/modules/extramodules-*
+Target = !usr/lib/modules/*/?*
+
+[Action]
+Exec = /usr/share/alpm/hooks.bin/dkms-remove
+When = PreTransaction
+Depends = dkms
+NeedsTargets

--- a/scripts/dkms-install
+++ b/scripts/dkms-install
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+while read -r path; do
+  for module in /usr/src/*; do
+    dkms install "$(basename "$module" | sed 's|-|/|')" -k "$(basename "$path")"
+  done
+done

--- a/scripts/dkms-remove
+++ b/scripts/dkms-remove
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+while read -r path; do
+  for module in /usr/src/*; do
+    dkms remove "$(basename "$module" | sed 's|-|/|')" -k "$(basename "$path")"
+  done
+done


### PR DESCRIPTION
These are generic dkms hooks to install/remove modules upon kernel install/upgrade/remove. Individual dkms packages should still have a hook or install script to handle this when they get installed/removed.
