### PR TITLE
Misc hooks + fixes

### DIFF
--- a/hooks/check-boot.hook
+++ b/hooks/check-boot.hook
@@ -1,5 +1,3 @@
-# Verify that /boot is mounted before trying to modify it
-
 [Trigger]
 Operation = Install
 Operation = Upgrade
@@ -8,6 +6,7 @@ Type = File
 Target = boot/*
 
 [Action]
+Description = Checking /boot is mounted before trying to modify it...
 When = PreTransaction
 Exec = /bin/sh -c 'findmnt /boot &>/dev/null || ( printf "error: /boot not mounted\n"; exit 1 )'
 AbortOnFail

--- a/hooks/check-suid.hook
+++ b/hooks/check-suid.hook
@@ -8,6 +8,7 @@ Target = usr/bin/*
 Target = usr/sbin/*
 
 [Action]
+Description = Checking for potentially-dangerous suid executables...
 When = PostTransaction
 Exec = /usr/share/alpm/hooks.bin/check-suid
 NeedsTargets

--- a/hooks/fc-cache.hook
+++ b/hooks/fc-cache.hook
@@ -6,5 +6,6 @@ Operation = Remove
 Target = usr/share/fonts/*
 
 [Action]
+Description = Updating font cache...
 When = PostTransaction
 Exec = /bin/fc-cache --system-only --force

--- a/hooks/gtk-update-icon-cache.hook
+++ b/hooks/gtk-update-icon-cache.hook
@@ -1,0 +1,13 @@
+[Trigger]
+Type = File
+Operation = Install
+Operation = Upgrade
+Operation = Remove
+Target = usr/share/icons/*/
+Target = !usr/share/icons/*/*/
+
+[Action]
+Description = Updating gtk icon cache...
+When = PostTransaction
+Exec = /bin/bash -c 'while read line; do gtk-update-icon-cache -q -t -f $line; done'
+NeedsTargets

--- a/hooks/info-install.hook
+++ b/hooks/info-install.hook
@@ -2,8 +2,7 @@
 Type = File
 Operation = Install
 Operation = Upgrade
-Target = usr/share/info/*
-Target = !usr/share/info/dir
+Target = usr/share/info/*.info*
 
 [Action]
 Description = Updating info/dir entries...

--- a/hooks/info-install.hook
+++ b/hooks/info-install.hook
@@ -6,6 +6,7 @@ Target = usr/share/info/*
 Target = !usr/share/info/dir
 
 [Action]
+Description = Updating info/dir entries...
 When = PostTransaction
 Exec = /bin/sh -c 'while read -r f; do install-info "$f" /usr/share/info/dir 2> /dev/null; done'
 NeedsTargets

--- a/hooks/info-remove.hook
+++ b/hooks/info-remove.hook
@@ -5,6 +5,7 @@ Target = usr/share/info/*
 Target = !usr/share/info/dir
 
 [Action]
+Description = Removing stale info/dir entries...
 When = PostTransaction
 Exec = /bin/sh -c 'while read -r f; do install-info --delete "$f" /usr/share/info/dir 2> /dev/null; done'
 NeedsTargets

--- a/hooks/info-remove.hook
+++ b/hooks/info-remove.hook
@@ -1,8 +1,7 @@
 [Trigger]
 Type = File
 Operation = Remove
-Target = usr/share/info/*
-Target = !usr/share/info/dir
+Target = usr/share/info/*.info*
 
 [Action]
 Description = Removing stale info/dir entries...

--- a/hooks/mkfontdir-otf.hook
+++ b/hooks/mkfontdir-otf.hook
@@ -6,5 +6,6 @@ Operation = Remove
 Target = usr/share/fonts/OTF/*
 
 [Action]
+Description = Indexing OTF fonts...
 When = PostTransaction
 Exec = /bin/mkfontdir /usr/share/fonts/OTF

--- a/hooks/mkfontdir-ttf.hook
+++ b/hooks/mkfontdir-ttf.hook
@@ -6,5 +6,6 @@ Operation = Remove
 Target = usr/share/fonts/TTF/*
 
 [Action]
+Description = Indexing TTF fonts...
 When = PostTransaction
 Exec = /bin/mkfontdir /usr/share/fonts/TTF

--- a/hooks/mkfontscale-otf.hook
+++ b/hooks/mkfontscale-otf.hook
@@ -6,5 +6,6 @@ Operation = Remove
 Target = usr/share/fonts/OTF/*
 
 [Action]
+Description = Indexing scalable TTF fonts...
 When = PostTransaction
 Exec = /bin/mkfontscale /usr/share/fonts/OTF

--- a/hooks/mkfontscale-ttf.hook
+++ b/hooks/mkfontscale-ttf.hook
@@ -6,5 +6,6 @@ Operation = Remove
 Target = usr/share/fonts/TTF/*
 
 [Action]
+Description = Indexing scalable OTF fonts...
 When = PostTransaction
 Exec = /bin/mkfontscale /usr/share/fonts/TTF

--- a/hooks/snapshot-post-snapper.hook
+++ b/hooks/snapshot-post-snapper.hook
@@ -6,5 +6,6 @@ Operation = Remove
 Target = *
 
 [Action]
+Description = Creating post-transaction system snapshot...
 When = PostInstall
 Exec = /usr/share/alpm/hooks.bin/snapshot-snapper post

--- a/hooks/snapshot-pre-snapper.hook
+++ b/hooks/snapshot-pre-snapper.hook
@@ -6,6 +6,7 @@ Operation = Remove
 Target = *
 
 [Action]
+Description = Creating pre-transaction system snapshot...
 When = PreInstall
 Exec = /usr/share/alpm/hooks.bin/snapshot-snapper pre
 AbortOnFail

--- a/hooks/sync.hook
+++ b/hooks/sync.hook
@@ -9,6 +9,6 @@ Type = Package
 Target = *
 
 [Action]
-Depends = coreutils
+Description = Force syncing changes to disk...
 When = PostTransaction
 Exec = /bin/sync

--- a/hooks/update-desktop-database.hook
+++ b/hooks/update-desktop-database.hook
@@ -6,5 +6,6 @@ Operation = Remove
 Target = usr/share/applications/*.desktop
 
 [Action]
+Description = Updating desktop database...
 When = PostTransaction
 Exec = /bin/update-desktop-database --quiet

--- a/hooks/update-mime-database.hook
+++ b/hooks/update-mime-database.hook
@@ -6,5 +6,6 @@ Operation = Remove
 Target = usr/share/mime/packages/*.xml
 
 [Action]
+Description = Updating mime database...
 When = PostTransaction
 Exec = /bin/update-mime-database /usr/share/mime

--- a/hooks/vimdoc.hook
+++ b/hooks/vimdoc.hook
@@ -1,0 +1,11 @@
+[Trigger]
+Type = File
+Operation = Install
+Operation = Upgrade
+Operation = Remove
+Target = usr/share/vim/vimfiles/doc/
+
+[Action]
+Description = Updating Vim help tags...
+When = PostTransaction
+Exec = /usr/bin/vim -es --cmd ":helptags /usr/share/vim/vimfiles/doc" --cmd ":q"


### PR DESCRIPTION
- A couple hooks I've been playing with:
  - vimdoc.hook
  - gtk-update-icon-cache.hook
- Based on the trick I used in gtk-update-icon-cache, I've also merged the mkfontdir/mkfontscale OTF/TTF hooks and made them apply to all fonts.
- update-mime-database should use a relative path, in case people are using an alternative `--root`.
- Also do a slightly better glob for install-info files, which also leaves out these pesky `.*\.png(\.gz)?` files (mainly owned by gnutls on my system). Really? I didn't know texinfo did images... but either way it is a waste of time to try indexing them, so why bother? :laughing:
- Add descriptions to the hooks, for eye candy.
