### PR TITLE
dont use --force since can lock a system

### DIFF
--- a/hooks/fc-cache.hook
+++ b/hooks/fc-cache.hook
@@ -7,4 +7,4 @@ Target = usr/share/fonts/*
 
 [Action]
 When = PostTransaction
-Exec = /bin/fc-cache --system-only --force
+Exec = /bin/fc-cache --system-only


### PR DESCRIPTION
--force can lock the system and up to today has ben removed from all repo fonts, read is a regresion.

look this todo for info https://www.archlinux.org/todo/fc-cache/ and search the diferents fonts reports for problems with --force either in the forum and in the bugtracker.
